### PR TITLE
Fixed warnings in compiler output

### DIFF
--- a/BRSim/BRSim.cpp
+++ b/BRSim/BRSim.cpp
@@ -1,9 +1,6 @@
 // BRSim.cpp : This file contains the 'main' function. Program execution begins and ends there.
 
-#include "glad/glad.h"
-#include "GLFW/glfw3.h"
-#include "glm/glm.hpp"
-#include "time.h"
+#include <Windows.h>
 #include <iostream>
 #include <memory.h>
 #include <thread>
@@ -16,6 +13,11 @@
 #include "Level.h"
 #include "Renderer.h"
 #include "Settings.h"
+
+#include "glad/glad.h"
+#include "GLFW/glfw3.h"
+#include "glm/glm.hpp"
+#include "time.h"
 
 //Window control variables
 GLFWwindow* mainWindow = nullptr;

--- a/BRSim/Game.cpp
+++ b/BRSim/Game.cpp
@@ -4,7 +4,7 @@ Game::Game(Level& level)
 	: levelData(level)
 {
 	circleCentre = glm::vec2(level.width / 2.0f, level.height / 2.0f);
-	circleRadius = glm::max<float>(level.width, level.height) * 1.5f;
+	circleRadius = (float)glm::max<int>(level.width, level.height) * 1.5f;
 	previousCircleRadius = circleRadius;
 	previousCircleCentre = circleCentre;
 	newCircle();

--- a/BRSim/Level.h
+++ b/BRSim/Level.h
@@ -3,7 +3,6 @@
 #include <string>
 
 #include "glm\glm.hpp"
-#include "lodepng.h"
 #include "Settings.h"
 #include "Texture.h"
 

--- a/BRSim/Texture.cpp
+++ b/BRSim/Texture.cpp
@@ -7,39 +7,12 @@ Texture::Texture()
 
 Texture::Texture(const char* fileName)
 {
-	loadFromTGA(fileName);
+	loadFromPNG(fileName);
 }
 
 Texture::~Texture()
 {
 	glDeleteTextures(1, &textureIndex);
-}
-
-void Texture::loadFromTGA(const char* fileName)
-{
-	GLbyte* pBits;
-	int nWidth, nHeight, nComponents;
-	GLenum eFormat;
-
-	pBits = readTGABits(fileName, &nWidth, &nHeight, &nComponents, &eFormat);
-	if (pBits == nullptr)
-	{
-		return;
-	}
-	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-	glGenTextures(1, &textureIndex);
-	glBindTexture(GL_TEXTURE_2D, textureIndex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, nWidth, nHeight, 0, eFormat, GL_UNSIGNED_BYTE, pBits);
-	free(pBits);
-	glGenerateMipmap(GL_TEXTURE_2D);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	GLfloat fLargest;
-	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &fLargest);
-	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, fLargest);
 }
 
 void Texture::use()
@@ -57,96 +30,6 @@ void Texture::loadFromPixels(std::vector<GLubyte> pixels, int width, int height)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glBindTexture(GL_TEXTURE_2D, 0);
-}
-
-
-////////////////////////////////////////////////////////////////////
-// Allocate memory and load targa bits. Returns pointer to new buffer,
-// height, and width of texture, and the OpenGL format of data.
-// Call free() on buffer when finished!
-// This only works on pretty vanilla targas... 8, 24, or 32 bit color
-// only, no palettes, no RLE encoding.
-// This function also takes an optional final parameter to preallocated 
-// storage for loading in the image data.
-GLbyte* readTGABits(const char* szFileName, GLint* iWidth, GLint* iHeight, GLint* iComponents, GLenum* eFormat, GLbyte* pData)
-{
-	FILE* pFile;			// File pointer
-	TGAHEADER tgaHeader;		// TGA file header
-	unsigned long lImageSize;		// Size in bytes of image
-	short sDepth;			// Pixel depth;
-	GLbyte* pBits = nullptr;          // Pointer to bits
-
-	// Default/Failed values
-	*iWidth = 0;
-	*iHeight = 0;
-	*eFormat = GL_RGB;
-	*iComponents = GL_RGB;
-
-	// Attempt to open the file
-	fopen_s(&pFile, szFileName, "rb");
-	if (pFile == nullptr)
-	{
-		return nullptr;
-	}
-	// Read in header (binary)
-	fread(&tgaHeader, 18/* sizeof(TGAHEADER)*/, 1, pFile);
-
-	// Get width, height, and depth of texture
-	*iWidth = tgaHeader.width;
-	*iHeight = tgaHeader.height;
-	sDepth = tgaHeader.bits / 8;
-
-	// Put some validity checks here. Very simply, I only understand
-	// or care about 8, 24, or 32 bit targa's.
-	if (tgaHeader.bits != 8 && tgaHeader.bits != 24 && tgaHeader.bits != 32)
-	{
-		return nullptr;
-	}
-
-	// Calculate size of image buffer
-	lImageSize = tgaHeader.width * tgaHeader.height * sDepth;
-
-	// Allocate memory and check for success
-	if (pData == nullptr)
-	{
-		pBits = (GLbyte*)malloc(lImageSize * sizeof(GLbyte));
-	}
-	else
-	{
-		pBits = pData;
-	}
-	// Read in the bits
-	// Check for read error. This should catch RLE or other 
-	// weird formats that I don't want to recognize
-	if (pBits != nullptr && fread(pBits, lImageSize, 1, pFile) != 1)
-	{
-		if (pBits != nullptr)
-		{
-			free(pBits);
-		}
-		return nullptr;
-	}
-
-	// Set OpenGL format expected
-	switch (sDepth)
-	{
-	case 4:
-		*eFormat = GL_BGRA;
-		*iComponents = GL_BGRA;// GL_RGBA;
-		break;
-	case 1:
-		*eFormat = GL_RED;		//Changed from GL_LUMINANCE due to removal in gl 3.1
-		*iComponents = GL_RED;
-		break;
-	default:        // RGB
-		break;
-	}
-
-	// Done with File
-	fclose(pFile);
-
-	// Return pointer to image data
-	return pBits;
 }
 
 void Texture::loadFromPNG(const char* fileName)

--- a/BRSim/Texture.h
+++ b/BRSim/Texture.h
@@ -4,27 +4,7 @@
 #include <cstdlib>
 #include <vector>
 #include "lodepng.h"
-
-GLbyte* readTGABits(const char* szFileName, GLint* iWidth, GLint* iHeight, GLint* iComponents, GLenum* eFormat, GLbyte* pData = nullptr);
-
-// Define targa header. This is only used locally.
-#pragma pack(1)
-typedef struct
-{
-	GLbyte	identsize;              // Size of ID field that follows header (0)
-	GLbyte	colorMapType;           // 0 = None, 1 = paletted
-	GLbyte	imageType;              // 0 = none, 1 = indexed, 2 = rgb, 3 = grey, +8=rle
-	unsigned short	colorMapStart;          // First colour map entry
-	unsigned short	colorMapLength;         // Number of colors
-	unsigned char 	colorMapBits;   // bits per palette entry
-	unsigned short	xstart;                 // image x origin
-	unsigned short	ystart;                 // image y origin
-	unsigned short	width;                  // width in pixels
-	unsigned short	height;                 // height in pixels
-	GLbyte	bits;                   // bits per pixel (8 16, 24, 32)
-	GLbyte	descriptor;             // image descriptor
-} TGAHEADER;
-#pragma pack(8)
+#pragma
 
 class Texture
 {
@@ -34,7 +14,6 @@ public:
 	Texture();
 	Texture(const char* filename);
 	~Texture();
-	void loadFromTGA(const char* fileName);
 	void loadFromPixels(std::vector<GLubyte> pixels, int width, int height);	//4 elements in array define a pixel in rgba format
 	void loadFromPNG(const char* fileName);
 	void use();


### PR DESCRIPTION
In some cases by adding suppresses to lodepng.cpp
Removed legacy TGA code loading.